### PR TITLE
Fix out of bounds error by flatmapping array down.

### DIFF
--- a/src/main/scala/edu/berkeley/cs/amplab/madd/util/FitsUtils.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/madd/util/FitsUtils.scala
@@ -95,14 +95,8 @@ object FitsUtils {
     // populate the axis array
     val naxis = Array(tcol, trow)
 
-    // compute the number of points in the set and allocate a linear array
-    val nax = tcol * trow
-    var data = Array.fill[Float](nax)(Float.NaN)
-
-    // copy rows into the array we've just allocated
-    for (i <- 0 until trow) {
-      Array.copy(matrix(i), 0, data, i * tcol, tcol)
-    }
+    // flat map the matrix down into a single long array
+    val data = matrix.flatMap(a => a)
 
     // allocate header unit and matrix
     val mtx: FitsMatrix = new FitsMatrix(ESOFits.DOUBLE, naxis)


### PR DESCRIPTION
Fixes an out of bounds error during the copy process by replacing the copy with a flatMap which reduces a matrix into a single long array.
